### PR TITLE
fix author affiliation structure

### DIFF
--- a/src/main/g8/out/peerj.tex
+++ b/src/main/g8/out/peerj.tex
@@ -24,7 +24,10 @@
 \title{$title$}
 
 $for(authors)$
-\author[$authors.position$]{$authors.name$} \affil[$authors.position$]{$authors.affiliation$}
+\author[$authors.affiliation$]{$authors.name$}
+$endfor$
+$for(affiliations)$
+\affil[$affiliations.number$]{$affiliations.name$}
 $endfor$
 
 \keywords{$for(keywords)$ $keywords$$sep$,$endfor$}

--- a/src/main/g8/paper.md
+++ b/src/main/g8/paper.md
@@ -2,15 +2,18 @@
 title: "We are really happy, and we don't know why"
 
 authors:
-- name: Salustiano Gonzalez
-  affiliation: Mi casa
-  position: 1
+- name: Salustiano González
+  affiliation: 1
 - name: Epifanio sincrético
-  affiliation: Su casa
-  position: 2
+  affiliation: 2
 - name: Ataúlfo encarnado
-  affiliation: Universidad de Lepe
-  position: 3
+  affiliation: 1
+
+affiliations:
+- number: 1
+  name: "Universidad de Lepe"
+- number: 2
+  name: "Un lugar de la Mancha"
 
 abstract: |
   Or _concrete_.


### PR DESCRIPTION
It should be in markdown header

``` md
- name: Eduardo Pareja-Tobes
  email: "eparejatobes@ohnosequences.com"
  affiliation: 1

affiliations:
  - number: 1
    name: "*[oh no sequences!](http://ohnosequences.com)* research group, [Era7 bioinformatics](http://www.era7bioinformatics.com)"
```

and in the pandoc template:

``` tex
$for(authors)$
\author[$authors.affiliation$]{$authors.name$}
$endfor$
$for(affiliations)$
\affil[$affiliations.number$]{$affiliations.name$}
$endfor$
```
